### PR TITLE
Add chdb stub module for optional dependency

### DIFF
--- a/src/chdb/__init__.py
+++ b/src/chdb/__init__.py
@@ -1,0 +1,21 @@
+"""Minimal stub of the :mod:`chdb` package used for testing.
+
+The real ``chdb`` package provides an in-memory ClickHouse implementation.
+This stub exposes a ``connect`` function so that our connection code can be
+imported and unit tested without requiring the actual dependency.  The
+function raises :class:`ImportError` to signal that the real package is
+missing.  Tests can monkeypatch :func:`connect` with a mock implementation.
+"""
+
+def connect(*args, **kwargs):
+    """Placeholder connect function.
+
+    Raises
+    ------
+    ImportError
+        Always raised to indicate that the real ``chdb`` package is not
+        installed.
+    """
+    raise ImportError(
+        "chdb package is required for CHDB connections. Install with: pip install chdb"
+    )


### PR DESCRIPTION
## Summary
- provide a minimal `chdb` stub so the library can be imported and unit-tested without the real dependency

## Testing
- `PYTHONPATH=src pytest tests/unit -q`
- `PYTHONPATH=src pytest tests/integration/sql_functions/test_format.py::test_format_bool -q` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ac0dba88e88332bf420559f8acf453